### PR TITLE
Bracket pair colorizer is a native feature in VS Code. Using native settings.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.bracketPairColorization.enabled": true,
+    "editor.guides.bracketPairs":"active"
+}


### PR DESCRIPTION
Using native settings for Bracket Pair Colorizer as the VS Code extension was depreciated.